### PR TITLE
ADD: Load :foreign-libs compiler options from EDN

### DIFF
--- a/resources/cljs_test_node_runner.cljs.edn
+++ b/resources/cljs_test_node_runner.cljs.edn
@@ -2,4 +2,5 @@
  :init-fns []
  :compiler-options {:main boot-cljs-test.node-runner
                     :target :nodejs
+                    :foreign-libs {{{foreign-libs}}}
                     :asset-path "target/out"}}


### PR DESCRIPTION
Hello

When using external Javascript libs, we need to use :foreign-libs to inform ClojureScript compiler where to find library and to reference it in our project.

We need to pass this information to node-runner so that it can configure _boot-cljs_ correctly.

The solution I used is by using _boot-cljs_ EDN file.

I am new to Clojure and even newer on _boot_. Feel free to comment this PR, I will refactor as needed.

Bertrand
